### PR TITLE
Write function line number before unique key in FN entries.

### DIFF
--- a/gjs/coverage.cpp
+++ b/gjs/coverage.cpp
@@ -81,6 +81,15 @@ write_string_into_stream(GOutputStream *stream,
 }
 
 static void
+write_uint32_into_stream(GOutputStream *stream,
+                         unsigned int   integer)
+{
+    char buf[32];
+    g_snprintf(buf, 32, "%u", integer);
+    g_output_stream_write(stream, (gconstpointer) buf, strlen(buf) * sizeof(char), NULL, NULL);
+}
+
+static void
 write_source_file_header(GOutputStream *stream,
                          const gchar   *source_file_path)
 {
@@ -163,15 +172,6 @@ write_functions(GOutputStream *data_stream,
                 GArray        *functions)
 {
     for_each_element_in_array(functions, write_function_foreach_func, data_stream);
-}
-
-static void
-write_uint32_into_stream(GOutputStream *stream,
-                         unsigned int   integer)
-{
-    char buf[32];
-    g_snprintf(buf, 32, "%u", integer);
-    g_output_stream_write(stream, (gconstpointer) buf, strlen(buf) * sizeof(char), NULL, NULL);
 }
 
 static void

--- a/gjs/coverage.cpp
+++ b/gjs/coverage.cpp
@@ -70,6 +70,7 @@ typedef struct _GjsCoverageBranch {
 
 typedef struct _GjsCoverageFunction {
     char         *key;
+    unsigned int line_number;
     unsigned int hit_count;
 } GjsCoverageFunction;
 
@@ -150,6 +151,8 @@ write_function_foreach_func(gpointer value,
     GjsCoverageFunction *function = (GjsCoverageFunction *) value;
 
     write_string_into_stream(stream, "FN:");
+    write_uint32_into_stream(stream, function->line_number);
+    write_string_into_stream(stream, ",");
     write_string_into_stream(stream, function->key);
     write_string_into_stream(stream, "\n");
 }
@@ -561,9 +564,11 @@ get_executed_lines_for(GjsCoverage *coverage,
 static void
 init_covered_function(GjsCoverageFunction *function,
                       char                *key,
+                      unsigned int        line_number,
                       unsigned int        hit_count)
 {
     function->key = key;
+    function->line_number = line_number;
     function->hit_count = hit_count;
 }
 
@@ -616,12 +621,21 @@ convert_and_insert_function_decl(GArray    *array,
         return FALSE;
     }
 
-    unsigned int line_number = JSVAL_TO_INT(hit_count_property_value);
+    jsval line_number_property_value;
+    if (!JS_GetProperty(context, object, "line", &line_number_property_value) ||
+        !JSVAL_IS_INT(line_number_property_value)) {
+        gjs_throw(context, "Failed to get line property for function object");
+        return FALSE;
+    }
+
+    unsigned int line_number = JSVAL_TO_INT(line_number_property_value);
+    unsigned int hit_count = JSVAL_TO_INT(hit_count_property_value);
 
     GjsCoverageFunction info;
     init_covered_function(&info,
                           utf8_string,
-                          line_number);
+                          line_number,
+                          hit_count);
 
     g_array_append_val(array, info);
 

--- a/modules/coverage.js
+++ b/modules/coverage.js
@@ -591,7 +591,10 @@ function _convertFunctionCountersToArray(functionCounters) {
      * of that object */
     for (let key in functionCounters) {
         let func = functionCounters[key];
+        /* The name of the function contains its line, after the first
+         * colon. Split the name and retrieve it here */
         arrayReturn.push({ name: key,
+                           line: Number(key.split(':')[1]),
                            hitCount: func.hitCount });
     }
 


### PR DESCRIPTION
Before we were not writing the line number before the unique key
but instead as part of the unique key. This is technically not
compliant with the lcov specification, which requires th
following:

    FN:<line number>,<function name>

For some reason, genhtml never complained about this and silently
just accepted the function names. Other tools that work with lcov
data, like lcov_cobertura and lcov-result-merge are far less
forgiving.

Fixes BGO #742362