### PR TITLE
Mute a warning

### DIFF
--- a/installed-tests/minijasmine.cpp
+++ b/installed-tests/minijasmine.cpp
@@ -34,7 +34,7 @@
 #include "gjs/mem.h"
 
 G_GNUC_NORETURN
-void
+static void
 bail_out(const char *msg)
 {
     g_print("Bail out! %s\n", msg);


### PR DESCRIPTION
Since this is a trivial patch, I have almost nothing to comment:
- it results in 'a warning free' compilation;
- so, we can enable -Werror.

Do I have to submit it via gnome 'zilla'?

[edited]
```
installed-tests/minijasmine.cpp: In function 'void bail_out(const char*)':
installed-tests/minijasmine.cpp:38:1: warning: no previous declaration for 'void bail_out(const char*)' [-Wmissing-declarations]
 bail_out(const char *msg)
```

To see why it is needed: `-- Werror` enabled on master.
https://travis-ci.org/claudioandre/gjs/builds/190217824
https://s3.amazonaws.com/archive.travis-ci.org/jobs/190217825/log.txt (at the end of the file)